### PR TITLE
Clarify default target address

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To start a tsuru + vagrant what you need to do is:
 $ vagrant up
 ~~~
 
+This will start a tsuru remote, or target, running at 192.168.50.4. Just browse to 192.168.50.4:8080 for further setup instructions!
+
 Supported providers
 ===================
 


### PR DESCRIPTION
I spent a good chunk of time trying to figure this out before I found the correct target address [buried](https://docs.tsuru.io/stable/contributing/vagrant.html) under the Contributing to tsuru page! Would've been helpful to have that documented here. :)